### PR TITLE
chore(template): move dev tooling into the dev dependency group

### DIFF
--- a/template/justfile
+++ b/template/justfile
@@ -18,14 +18,14 @@ update-hooks:
 
 # Code quality ----------------------------------------------------------------
 format:
-    ruff check --select I --fix .
-    ruff format .
+    uv run ruff check --select I --fix .
+    uv run ruff format .
 
 check-types:
-    ty check src
+    uv run ty check src
 
 check-complexity:
-    uvx complexipy src
+    uv run complexipy src
 
 # Test and run ----------------------------------------------------------------
 test target="":

--- a/template/pyproject.toml.jinja
+++ b/template/pyproject.toml.jinja
@@ -12,8 +12,11 @@ dependencies = []
 # Dev / optional dependencies -------------------------------------------------
 [dependency-groups]
 dev = [
+    "complexipy",
     "pytest-cov",
-]  # complexipy, ruff, ty must be installed globally via uvx / uv tool
+    "ruff",
+    "ty",
+]
 
 # Build backend ---------------------------------------------------------------
 [build-system]


### PR DESCRIPTION
Closes #1

## Summary
Moves `ruff`, `ty`, and `complexipy` from "must be installed globally" into `[dependency-groups].dev` of `template/pyproject.toml.jinja`, and updates `template/justfile` so `format`, `check-types`, and `check-complexity` invoke them via `uv run` instead of system binaries / `uvx`. A freshly generated project now needs only `uv` and `just` on PATH; tool versions are pinned via `uv.lock`.

## Breaking changes
None for existing generated projects (they are not regenerated automatically). Newly generated projects no longer require global `ruff`/`ty`/`complexipy` installs.

## Notes for reviewer
- Dev group entries are unpinned (`"ruff"`, `"ty"`, `"complexipy"`) to mirror the existing style of `"pytest-cov"`; pinning is left to `uv.lock`. Happy to add lower bounds if you'd prefer.
- `ty` is still pre-1.0 (resolved to `0.0.32`); pulling it through `uv.lock` means template consumers get reproducible versions, which is an improvement over the previous unpinned global install.
- Did not touch `template/prek.toml` — its local hooks shell out to `just …`, so they pick up the `uv run` change for free.

## Test plan
Generated a sample project with `copier copy --trust . /tmp/sample` (defaults, MIT, py3.13) and ran, with only `uv` + `just` on PATH:
- `just sync` — resolved and installed `ruff 0.15.12`, `ty 0.0.32`, `complexipy`, `pytest-cov 7.1.0` into `.venv`.
- `just format` — ✅ ruff check + format via `uv run`.
- `just check-types` — ✅ `uv run ty check src`.
- `just check-complexity` — ✅ `uv run complexipy src`.
- `just test` — ✅ pytest with coverage gate.
- `prek run --all-files ruff-format check-types check-complexity` — ✅ all three local hooks passed.
