### PR TITLE
ci(template): drive verification from prek for a single source of truth

### DIFF
--- a/template/.github/workflows/verify.yml
+++ b/template/.github/workflows/verify.yml
@@ -1,4 +1,6 @@
-# This workflow runs tests, linting and type hinting for every push
+# This workflow runs all per-file checks (via prek) and the test suite for every push.
+# prek.toml is the single source of truth for hook versions and per-file checks;
+# this workflow only orchestrates `prek run --all-files` and `just test`.
 
 name: verify
 
@@ -31,17 +33,14 @@ jobs:
       - name: Install just
         uses: extractions/setup-just@v3
 
-      - name: Install the project
-        run: just sync
+      - name: Install prek
+        run: uv tool install prek
 
-      - name: Run linting
-        run: just format
+      - name: Install the project (frozen)
+        run: just install
 
-      - name: Run type checks
-        run: just check-types
-
-      - name: Run complexity analysis
-        run: just check-complexity
+      - name: Run prek hooks
+        run: prek run --all-files --show-diff-on-failure --color always
 
       - name: Run tests
         run: just test

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -22,7 +22,8 @@ The `uv.lock` file is committed to source control so CI and contributors install
 exact same dependency versions. Use `just upgrade` to refresh the lockfile.
 
 ```bash
-just sync               # install dependencies
+just install            # install deps from the lockfile (matches CI)
+just upgrade            # refresh the lockfile and sync
 just install-hooks      # set up pre-commit hooks
 just test               # run tests with coverage
 just format             # lint + format

--- a/template/README.md.jinja
+++ b/template/README.md.jinja
@@ -18,6 +18,9 @@ import {{ project_slug }}
 
 This project uses [uv](https://docs.astral.sh/uv/), [just](https://just.systems/) and [prek](https://github.com/j178/prek).
 
+The `uv.lock` file is committed to source control so CI and contributors install the
+exact same dependency versions. Use `just upgrade` to refresh the lockfile.
+
 ```bash
 just sync               # install dependencies
 just install-hooks      # set up pre-commit hooks

--- a/template/justfile
+++ b/template/justfile
@@ -24,7 +24,7 @@ update-hooks:
 
 # Code quality ----------------------------------------------------------------
 format:
-    uv run ruff check --select I --fix .
+    uv run ruff check --fix .
     uv run ruff format .
 
 check-types:

--- a/template/justfile
+++ b/template/justfile
@@ -1,13 +1,19 @@
 set dotenv-load := true
 
 # Python environment ----------------------------------------------------------
-sync:
+# Refresh the lockfile and sync (use when you intentionally want newer deps).
+upgrade:
     uv lock --upgrade
     uv sync --all-extras --all-groups
 
+# Install from the committed lockfile (matches CI).
+install:
+    uv sync --frozen --all-extras --all-groups
+
+# Nuke the venv and reinstall from the lockfile (last-resort env reset).
 reset-env:
     rm -rf .venv
-    uv sync
+    uv sync --frozen --all-extras --all-groups
 
 # Pre-commit hooks ------------------------------------------------------------
 install-hooks:


### PR DESCRIPTION
Closes #2

## Summary
Make `prek.toml` the single source of truth for per-file checks and hook
versions. CI now runs `prek run --all-files` plus `just test`, instead of
mirroring per-tool invocations across `justfile` and `verify.yml`. The
justfile gains explicit `upgrade` / `install` env recipes so CI installs
from the committed `uv.lock` (`--frozen`) and never silently upgrades.

## Breaking changes
For projects generated from this template:

- `just sync` is gone. Use `just install` (frozen, matches CI) or
  `just upgrade` (refresh the lockfile).
- `just format` now runs the full configured ruff rule set
  (`D, E, F, I, UP, B, SIM, RUF`), not just import sorting. Existing
  generated projects may surface new lint findings on first run.
- CI installs with `--frozen`, so an out-of-date `uv.lock` will fail
  verification instead of being auto-updated.

## Notes for reviewer
- `verify.yml` installs prek via `uv tool install prek`. Open to switching
  to pipx or a dedicated action if you prefer.
- `reset-env` was kept (handy when the venv breaks) but tightened to
  `uv sync --frozen --all-extras --all-groups` so a reset reproduces the
  CI environment.
- Smoke-checked locally that the template `justfile` parses and recipe
  names referenced by `prek.toml` local hooks are unchanged. Full
  generated-project CI verification (red paths for unformatted file,
  lint violation, type error, complexity violation, leaked secret,
  misspelling, lockfile drift) is left for manual confirmation, as
  agreed.

## Test plan
- `just --justfile template/justfile --list` — recipes resolve.
- `grep -i lock template/.gitignore` — `uv.lock` not excluded.
- Manual: regenerate a sample project and confirm CI fails on each of
  the violation types listed in the issue's done criteria.
